### PR TITLE
Don't return directories when globbing.

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -28,7 +28,7 @@ async function run() {
     for(let i = 0; i < assetPaths.length; i++) {
       let assetPath = assetPaths[i];
       if(assetPath.indexOf("*") > -1) {
-        const files = glob.sync(assetPath)
+        const files = glob.sync(assetPath, { nodir: true })
           for (const file of files) {
             paths.push(file)
         }


### PR DESCRIPTION
Turns out glob has an option for exactly this. You can see it in action here:
https://github.com/Kansattica/upload-assets/runs/1360687424?check_suite_focus=true
https://github.com/Kansattica/upload-assets/releases/tag/refs%2Fheads%2FCI-test

This should resolve issue #1.